### PR TITLE
Add Testing with testthat and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Sample .travis.yml for R projects.
+#
+# See README.md for instructions, or for more configuration options,
+# see the wiki:
+#   https://github.com/craigcitro/r-travis/wiki
+
+language: c
+
+before_install:
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+install:
+  - ./travis-tool.sh install_deps
+script: ./travis-tool.sh run_tests
+
+after_failure:
+  - ./travis-tool.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,13 @@
 Package: cats
-Title: What the package does (short line)
+Title: Cats
 Version: 0.1
-Authors@R: "First Last <first.last@example.com> [aut, cre]"
-Description: What the package does (paragraph)
+Author: Hilary Parker <hilary@etsy.com> [aut, cre]
+Maintainer: Hilary Parker <hilary@etsy.com> 
+Authors@R: c( person("Hilary", "Parker", email = "hilary@etsy.com", role = c("aut", "cre")))
+Description: Mew.
 Depends:
     R (>= 3.0.2)
-License: What license is it under?
+License: MIT
 LazyData: true
+Suggests: 
+  testthat

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ If you see
     Running ‘testthat.R’
     OK
 You didn't break anything! Or possibly didn't add tests for new things you've added.
+
+There is also a .travis.yml file which, if you have an account on [Travis CI](http://travis-ci.org), will automatically run tests and ensure this can still be packaged when changes are made. The image below shows the current test & package build success status on the master branch of markolson/cats. Update to suit. 
+
+[![Build Status](https://travis-ci.org/markolson/cats.svg?branch=master)](https://travis-ci.org/markolson/cats)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@ cats
 ====
 
 An R package for cat-related functions, as originally [outlined on Hilary's blog](http://hilaryparker.com/2014/04/29/writing-an-r-package-from-scratch/), and brought to life by [#rcatladies](https://twitter.com/search?src=typd&q=%23rcatladies).
+
+
+## Testing
+
+The cat related functions are tested with [testthat](https://github.com/hadley/testthat), and can be run in an R console with
+
+     library(testthat)
+     test_file('tests/testthat.R')
+Or from the command line (assuming you are in the `cats` folder) with
+
+    cd .. && r CMD check cats && cd -
+If you see
+
+    Running ‘testthat.R’
+    OK
+You didn't break anything! Or possibly didn't add tests for new things you've added.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(cats)
+
+test_check("cats")

--- a/tests/testthat/test-cat_function.R
+++ b/tests/testthat/test-cat_function.R
@@ -1,0 +1,13 @@
+context("cat_function")
+
+test_that("Cat lovers are appreciated", {
+  expect_that(cat_function(TRUE), prints_text("I love cats!"))
+})
+
+test_that("Cat haters are scored", {
+  expect_that(cat_function(FALSE), prints_text("I am not a cool person."))
+})
+
+#test_that("Dog people are cool, though", {
+#  expect_that(dog_function(TRUE), prints_text("Very cool person."))
+#})


### PR DESCRIPTION
Having automated tests is an important part of any library, helping ensure that you don't accidentally break anything as you add new features, or rework existing ones. Hadley Wickham wrote [testthat](https://github.com/hadley/testthat), a small library to provide basic assertions about the functionality of code. The `tests/testthat/test-cat_function.R` file contains tests for both the TRUE and FALSE conditions of `cat_function`, along with a 3rd test for an unwritten function that if uncommented, will cause the tests to fail. 

Finally, a `.travis.yml` file has been added. [Travis CI](http://travis-ci.org) is a Continuous Integration tool that you can use in conjunction with Github to automatically run tests each time you submit code to a branch. It also will show a pass/fail on pull requests, letting you see if problems have been introduced. If this is merged in, the README should be updated to include new Travis CI information.
